### PR TITLE
feat: build Hero section with name, role, CTA and language switcher

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { motion } from "framer-motion";
+import { Github, Linkedin, MapPin, Download } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { cvData } from "@/data/cv";
+
+const { personalInfo } = cvData;
+
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.12 } },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+};
+
+export function Hero() {
+  const t = useTranslations("Hero");
+
+  return (
+    <section
+      className="flex min-h-[90vh] flex-col items-center justify-center px-6 py-24 text-center"
+      aria-label="Hero"
+    >
+      <motion.div
+        className="flex max-w-2xl flex-col items-center gap-6"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Location pill */}
+        <motion.div variants={itemVariants}>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-3 py-1 text-xs text-[var(--text-muted)]">
+            <MapPin size={12} aria-hidden="true" />
+            {personalInfo.location}
+          </span>
+        </motion.div>
+
+        {/* Name */}
+        <motion.h1
+          variants={itemVariants}
+          className="text-4xl font-bold tracking-tight text-[var(--foreground)] sm:text-5xl lg:text-6xl"
+        >
+          {personalInfo.name}
+        </motion.h1>
+
+        {/* Role */}
+        <motion.p
+          variants={itemVariants}
+          className="text-lg font-medium text-[var(--text-muted)] sm:text-xl"
+        >
+          {t("subtitle")}
+        </motion.p>
+
+        {/* Tagline */}
+        <motion.p
+          variants={itemVariants}
+          className="max-w-xl text-base text-[var(--text-muted)]"
+        >
+          {t("title")}
+        </motion.p>
+
+        {/* CTA row */}
+        <motion.div
+          variants={itemVariants}
+          className="flex flex-wrap items-center justify-center gap-3"
+        >
+          <Button
+            variant="primary"
+            aria-label={t("cta")}
+            onClick={() => window.open("/cv.pdf", "_blank")}
+          >
+            <Download size={15} aria-hidden="true" />
+            {t("cta")}
+          </Button>
+
+          <a
+            href={personalInfo.contact.linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn profile"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] text-[var(--text-muted)] transition-colors hover:text-[var(--foreground)]"
+          >
+            <Linkedin size={16} aria-hidden="true" />
+          </a>
+
+          <a
+            href={personalInfo.contact.github}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub profile"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] text-[var(--text-muted)] transition-colors hover:text-[var(--foreground)]"
+          >
+            <Github size={16} aria-hidden="true" />
+          </a>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -1,0 +1,19 @@
+import { LanguageSwitcher } from "@/components/ui/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { cvData } from "@/data/cv";
+
+export function Navbar() {
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-[var(--border)] bg-[var(--background)]/80 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
+        <span className="text-sm font-semibold tracking-tight text-[var(--foreground)]">
+          {cvData.personalInfo.name}
+        </span>
+        <div className="flex items-center gap-3">
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,40 @@
+import { type ButtonHTMLAttributes, forwardRef } from "react";
+import { clsx } from "clsx";
+
+type ButtonVariant = "primary" | "ghost" | "outline";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  asChild?: boolean;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-[var(--accent)] text-[var(--accent-fg)] hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+  ghost:
+    "bg-transparent text-[var(--foreground)] hover:bg-[var(--surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--border)]",
+  outline:
+    "border border-[var(--border)] bg-transparent text-[var(--foreground)] hover:bg-[var(--surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--border)]",
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = "primary", className, children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={clsx(
+          "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-150 outline-none focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+          variantClasses[variant],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/src/components/ui/LanguageSwitcher.tsx
+++ b/src/components/ui/LanguageSwitcher.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+import { clsx } from "clsx";
+
+const localeLabels: Record<string, string> = {
+  en: "EN",
+  es: "ES",
+  fr: "FR",
+};
+
+export function LanguageSwitcher() {
+  const locale = useLocale();
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Language switcher">
+      <ul className="flex items-center gap-1">
+        {routing.locales.map((loc) => (
+          <li key={loc}>
+            <Link
+              href={pathname}
+              locale={loc}
+              className={clsx(
+                "rounded px-2 py-1 text-xs font-semibold uppercase tracking-wider transition-colors",
+                locale === loc
+                  ? "text-[var(--foreground)]"
+                  : "text-[var(--text-muted)] hover:text-[var(--foreground)]"
+              )}
+              aria-label={`Switch to ${loc.toUpperCase()}`}
+              aria-current={locale === loc ? "true" : undefined}
+            >
+              {localeLabels[loc]}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="h-8 w-8" aria-hidden="true" />;
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--text-muted)] transition-colors hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--border)]"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun size={16} /> : <Moon size={16} />}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Builds all core UI atoms and the Hero section — first visible content of the portfolio.

### New components
| File | Description |
|------|-------------|
| `src/components/ui/Button.tsx` | Accessible button atom with `primary`, `ghost`, `outline` variants |
| `src/components/ui/LanguageSwitcher.tsx` | EN/ES/FR switcher using next-intl typed `Link` |
| `src/components/ui/ThemeToggle.tsx` | Sun/Moon toggle with `aria-label` |
| `src/components/sections/Navbar.tsx` | Fixed header: name + LanguageSwitcher + ThemeToggle |
| `src/components/sections/Hero.tsx` | Full-viewport hero with Framer Motion staggered entrance |

### Hero content (sourced from `cvData`)
- Name, specialization, location pill
- Tagline and role from `Hero.*` i18n keys
- Download CV CTA button + LinkedIn + GitHub icon links

## How to test
1. `npm run dev` → visit `/en`, `/es`, `/fr` — hero renders in each language
2. Toggle dark mode — ThemeToggle switches correctly
3. Click language switcher — locale changes without full reload
4. Tab through hero — all interactive elements are keyboard accessible
5. `next build` passes 0 errors

Closes #5
