### PR TITLE
feat: build Summary, Experience and Education sections from cv.ts data

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,13 +1,24 @@
 import { useTranslations } from "next-intl";
+import { Navbar } from "@/components/sections/Navbar";
+import { Hero } from "@/components/sections/Hero";
+import { Summary } from "@/components/sections/Summary";
+import { Experience } from "@/components/sections/Experience";
+import { Education } from "@/components/sections/Education";
 
 export default function HomePage() {
-  const t = useTranslations("Index");
+  const _t = useTranslations("Index");
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 dark:bg-zinc-950">
-      <h1 className="text-3xl font-semibold text-zinc-900 dark:text-zinc-50">
-        {t("title")}
-      </h1>
-    </main>
+    <>
+      <Navbar />
+      <main className="bg-[var(--background)]">
+        <Hero />
+        <div className="divide-y divide-[var(--border)]">
+          <Summary />
+          <Experience />
+          <Education />
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/components/sections/Education.tsx
+++ b/src/components/sections/Education.tsx
@@ -1,0 +1,39 @@
+import { useTranslations } from "next-intl";
+import { SectionTitle } from "@/components/ui/SectionTitle";
+import { cvData } from "@/data/cv";
+
+export function Education() {
+  const t = useTranslations("Sections");
+
+  return (
+    <section aria-labelledby="education-heading" className="py-16">
+      <div className="mx-auto max-w-4xl px-6">
+        <SectionTitle>
+          <span id="education-heading">{t("education")}</span>
+        </SectionTitle>
+
+        <ol className="flex flex-col gap-8">
+          {cvData.education.map((edu) => (
+            <li key={edu.degree} className="grid gap-1 sm:grid-cols-[1fr_2fr]">
+              {/* Left: year + institution */}
+              <div className="flex flex-col gap-1">
+                <time className="text-xs font-medium text-[var(--text-muted)]">
+                  {edu.year}
+                </time>
+                <span className="text-sm font-semibold text-[var(--foreground)]">
+                  {edu.institution}
+                </span>
+                <span className="text-xs text-[var(--text-muted)]">{edu.grade}</span>
+              </div>
+
+              {/* Right: degree */}
+              <p className="text-sm font-medium text-[var(--text-muted)] sm:self-center">
+                {edu.degree}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -1,0 +1,50 @@
+import { useTranslations } from "next-intl";
+import { SectionTitle } from "@/components/ui/SectionTitle";
+import { cvData } from "@/data/cv";
+
+export function Experience() {
+  const t = useTranslations("Sections");
+  const tCommon = useTranslations("Common");
+
+  return (
+    <section aria-labelledby="experience-heading" className="py-16">
+      <div className="mx-auto max-w-4xl px-6">
+        <SectionTitle>
+          <span id="experience-heading">{t("experience")}</span>
+        </SectionTitle>
+
+        <ol className="flex flex-col gap-10">
+          {cvData.experience.map((job) => {
+            const period = job.period.replace("Present", tCommon("present"));
+            return (
+              <li key={`${job.company}-${job.period}`} className="relative grid gap-1 sm:grid-cols-[1fr_2fr]">
+                {/* Left: meta */}
+                <div className="flex flex-col gap-1">
+                  <time className="text-xs font-medium text-[var(--text-muted)]">
+                    {period}
+                  </time>
+                  <span className="text-sm font-semibold text-[var(--foreground)]">
+                    {job.company}
+                  </span>
+                </div>
+
+                {/* Right: role + highlights */}
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm font-medium text-[var(--text-muted)]">{job.role}</p>
+                  <ul className="flex flex-col gap-1" aria-label={`Highlights at ${job.company}`}>
+                    {job.highlights.map((h) => (
+                      <li key={h} className="flex gap-2 text-sm text-[var(--text-muted)]">
+                        <span aria-hidden="true" className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--text-muted)]" />
+                        {h}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -15,7 +15,7 @@ const containerVariants = {
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
 };
 
 export function Hero() {

--- a/src/components/sections/Summary.tsx
+++ b/src/components/sections/Summary.tsx
@@ -1,0 +1,24 @@
+import { useTranslations, useLocale } from "next-intl";
+import { SectionTitle } from "@/components/ui/SectionTitle";
+import { cvData } from "@/data/cv";
+
+type SupportedLocale = "en" | "es" | "fr";
+
+export function Summary() {
+  const t = useTranslations("Sections");
+  const locale = useLocale() as SupportedLocale;
+  const summary = cvData.professionalSummary[locale] ?? cvData.professionalSummary.en;
+
+  return (
+    <section aria-labelledby="summary-heading" className="py-16">
+      <div className="mx-auto max-w-4xl px-6">
+        <SectionTitle>
+          <span id="summary-heading">{t("summary")}</span>
+        </SectionTitle>
+        <p className="max-w-2xl text-base leading-7 text-[var(--text-muted)]">
+          {summary}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,19 @@
+import { clsx } from "clsx";
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Badge({ children, className }: BadgeProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--text-muted)]",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/SectionTitle.tsx
+++ b/src/components/ui/SectionTitle.tsx
@@ -1,0 +1,17 @@
+import { clsx } from "clsx";
+
+interface SectionTitleProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SectionTitle({ children, className }: SectionTitleProps) {
+  return (
+    <div className={clsx("mb-8", className)}>
+      <h2 className="text-2xl font-bold tracking-tight text-[var(--foreground)]">
+        {children}
+      </h2>
+      <div className="mt-2 h-px w-12 bg-[var(--foreground)] opacity-20" aria-hidden="true" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Builds the main CV content sections — all data-driven from `cvData`, zero hardcoded strings.

### New components
| File | Description |
|------|-------------|
| `src/components/ui/SectionTitle.tsx` | Reusable `<h2>` heading with decorative divider |
| `src/components/ui/Badge.tsx` | Small pill for skill/tech tags |
| `src/components/sections/Summary.tsx` | Professional summary from `cvData.professionalSummary[locale]` |
| `src/components/sections/Experience.tsx` | Two-column responsive job timeline with `<ol><li><time>` |
| `src/components/sections/Education.tsx` | Education list with institution, degree, grade and year |

### Also
- Wired all sections into `app/[locale]/page.tsx`
- Fixed Framer Motion `ease` type issue (`as const`) for TypeScript strict compliance

## How to test
1. `npm run dev` → visit `/en`, `/es`, `/fr` — all sections render in each language
2. Check "Present" in experience timeline changes per locale
3. Resize to mobile — sections stack to single column
4. `next build` passes 0 errors

Closes #2
