### PR TITLE
feat: build Skills and Languages sections with scroll animations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -15,6 +15,13 @@
     "education": "Education",
     "languages": "Languages"
   },
+  "Skills": {
+    "management": "Management",
+    "backend": "Backend",
+    "frontend": "Frontend",
+    "infrastructure": "Infrastructure",
+    "databases": "Databases"
+  },
   "Common": {
     "present": "Present",
     "remote": "Remote"

--- a/messages/es.json
+++ b/messages/es.json
@@ -15,6 +15,13 @@
     "education": "Formación",
     "languages": "Idiomas"
   },
+  "Skills": {
+    "management": "Gestión",
+    "backend": "Backend",
+    "frontend": "Frontend",
+    "infrastructure": "Infraestructura",
+    "databases": "Bases de datos"
+  },
   "Common": {
     "present": "Actualidad",
     "remote": "Remoto"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -15,6 +15,13 @@
     "education": "Éducation",
     "languages": "Langues"
   },
+  "Skills": {
+    "management": "Management",
+    "backend": "Backend",
+    "frontend": "Frontend",
+    "infrastructure": "Infrastructure",
+    "databases": "Bases de données"
+  },
   "Common": {
     "present": "Présent",
     "remote": "À distance"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,6 +4,8 @@ import { Hero } from "@/components/sections/Hero";
 import { Summary } from "@/components/sections/Summary";
 import { Experience } from "@/components/sections/Experience";
 import { Education } from "@/components/sections/Education";
+import { Skills } from "@/components/sections/Skills";
+import { Languages } from "@/components/sections/Languages";
 
 export default function HomePage() {
   const _t = useTranslations("Index");
@@ -15,8 +17,10 @@ export default function HomePage() {
         <Hero />
         <div className="divide-y divide-[var(--border)]">
           <Summary />
+          <Skills />
           <Experience />
           <Education />
+          <Languages />
         </div>
       </main>
     </>

--- a/src/components/sections/Languages.tsx
+++ b/src/components/sections/Languages.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { motion } from "framer-motion";
+import { SectionTitle } from "@/components/ui/SectionTitle";
+import { cvData } from "@/data/cv";
+
+const levelColors: Record<string, string> = {
+  Native: "bg-[var(--foreground)]",
+  "B2.2 (Professional)": "bg-[var(--foreground)] opacity-70",
+  "B1 (Intermediate)": "bg-[var(--foreground)] opacity-40",
+};
+
+export function Languages() {
+  const t = useTranslations("Sections");
+
+  return (
+    <section aria-labelledby="languages-heading" className="py-16">
+      <div className="mx-auto max-w-4xl px-6">
+        <SectionTitle>
+          <span id="languages-heading">{t("languages")}</span>
+        </SectionTitle>
+
+        <ul className="flex flex-col gap-4">
+          {cvData.languages.map((lang, i) => (
+            <motion.li
+              key={lang.language}
+              initial={{ opacity: 0, x: -12 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.35, delay: i * 0.08, ease: "easeOut" as const }}
+              className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--surface)] px-5 py-3"
+            >
+              <span className="text-sm font-medium text-[var(--foreground)]">
+                {lang.language}
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-[var(--text-muted)]">{lang.level}</span>
+                <div
+                  className={`h-2 w-2 rounded-full ${levelColors[lang.level] ?? "bg-[var(--text-muted)]"}`}
+                  aria-hidden="true"
+                />
+              </div>
+            </motion.li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { motion } from "framer-motion";
+import { SectionTitle } from "@/components/ui/SectionTitle";
+import { Badge } from "@/components/ui/Badge";
+import { cvData } from "@/data/cv";
+
+type SkillCategory = keyof typeof cvData.skills;
+
+const categoryOrder: SkillCategory[] = [
+  "management",
+  "backend",
+  "frontend",
+  "infrastructure",
+  "databases",
+];
+
+export function Skills() {
+  const t = useTranslations("Sections");
+  const tSkills = useTranslations("Skills");
+
+  return (
+    <section aria-labelledby="skills-heading" className="py-16">
+      <div className="mx-auto max-w-4xl px-6">
+        <SectionTitle>
+          <span id="skills-heading">{t("skills")}</span>
+        </SectionTitle>
+
+        <div className="grid gap-6 sm:grid-cols-2">
+          {categoryOrder.map((category, i) => (
+            <motion.div
+              key={category}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.4, delay: i * 0.07, ease: "easeOut" as const }}
+              className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5"
+              aria-label={`${tSkills(category)} skills`}
+            >
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+                {tSkills(category)}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {cvData.skills[category].map((skill) => (
+                  <Badge key={skill}>{skill}</Badge>
+                ))}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Adds the Skills and Languages sections with scroll-triggered Framer Motion animations.

### New components
| File | Description |
|------|-------------|
| `src/components/sections/Skills.tsx` | 5-category skill grid with `whileInView` staggered entrance |
| `src/components/sections/Languages.tsx` | Language list with level tag and colour indicator |

### Also
- Added `Skills.*` i18n keys to `messages/en.json`, `es.json`, `fr.json`
- Wired both sections into `app/[locale]/page.tsx`

## How to test
1. `npm run dev` → scroll down past Summary — skill cards animate in one by one
2. Check skill category labels translate in `/es` and `/fr`
3. Languages section shows Native / B2.2 / B1 levels with indicators
4. `next build` passes 0 errors

Closes #3
