### PR TITLE
feat: add SEO metadata, CV PDF download and production readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/public/cv.pdf
+++ b/public/cv.pdf
@@ -1,0 +1,1 @@
+%PDF-1.4 placeholder CV

--- a/src/__tests__/cv.test.ts
+++ b/src/__tests__/cv.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { cvData } from "@/data/cv";
+
+describe("cvData shape", () => {
+  it("has required personalInfo fields", () => {
+    const { personalInfo } = cvData;
+    expect(personalInfo.name).toBeTruthy();
+    expect(personalInfo.role).toBeTruthy();
+    expect(personalInfo.location).toBeTruthy();
+    expect(personalInfo.contact.email).toBeTruthy();
+    expect(personalInfo.contact.linkedin).toBeTruthy();
+    expect(personalInfo.contact.github).toBeTruthy();
+  });
+
+  it("has professionalSummary for all three locales", () => {
+    expect(cvData.professionalSummary.en).toBeTruthy();
+    expect(cvData.professionalSummary.es).toBeTruthy();
+    expect(cvData.professionalSummary.fr).toBeTruthy();
+  });
+
+  it("has at least one experience entry with required fields", () => {
+    expect(cvData.experience.length).toBeGreaterThan(0);
+    for (const job of cvData.experience) {
+      expect(job.company).toBeTruthy();
+      expect(job.role).toBeTruthy();
+      expect(job.period).toBeTruthy();
+      expect(job.highlights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has at least one education entry with required fields", () => {
+    expect(cvData.education.length).toBeGreaterThan(0);
+    for (const edu of cvData.education) {
+      expect(edu.degree).toBeTruthy();
+      expect(edu.institution).toBeTruthy();
+      expect(edu.grade).toBeTruthy();
+      expect(edu.year).toBeTruthy();
+    }
+  });
+
+  it("has all skills categories populated", () => {
+    const { skills } = cvData;
+    expect(skills.management.length).toBeGreaterThan(0);
+    expect(skills.backend.length).toBeGreaterThan(0);
+    expect(skills.frontend.length).toBeGreaterThan(0);
+    expect(skills.infrastructure.length).toBeGreaterThan(0);
+    expect(skills.databases.length).toBeGreaterThan(0);
+  });
+
+  it("has at least one language entry", () => {
+    expect(cvData.languages.length).toBeGreaterThan(0);
+    for (const lang of cvData.languages) {
+      expect(lang.language).toBeTruthy();
+      expect(lang.level).toBeTruthy();
+    }
+  });
+});

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getMessages, getTranslations } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
 import { routing } from "@/i18n/routing";
+import { cvData } from "@/data/cv";
 import "../globals.css";
 import { notFound } from "next/navigation";
 
@@ -17,10 +18,41 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata: Metadata = {
-  title: "Marc Ruiz — Senior Software Engineer",
-  description: "Portfolio of a Senior Software Engineer transitioning to Engineering Management.",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Index" });
+  const { personalInfo } = cvData;
+  const url = `https://marcruiz.dev/${locale}`;
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    metadataBase: new URL("https://marcruiz.dev"),
+    alternates: {
+      canonical: url,
+      languages: Object.fromEntries(
+        routing.locales.map((loc) => [loc, `https://marcruiz.dev/${loc}`])
+      ),
+    },
+    openGraph: {
+      type: "website",
+      url,
+      title: t("title"),
+      description: t("description"),
+      locale,
+      siteName: personalInfo.name,
+    },
+    twitter: {
+      card: "summary",
+      title: t("title"),
+      description: t("description"),
+    },
+  };
+}
 
 export default async function LocaleLayout({
   children,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: "https://marcruiz.dev/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { routing } from "@/i18n/routing";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return routing.locales.map((locale) => ({
+    url: `https://marcruiz.dev/${locale}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: locale === routing.defaultLocale ? 1 : 0.8,
+    alternates: {
+      languages: Object.fromEntries(
+        routing.locales.map((loc) => [loc, `https://marcruiz.dev/${loc}`])
+      ),
+    },
+  }));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
Finalizes the portfolio for production: locale-aware SEO metadata, sitemap, robots.txt, CV download and a full Vitest smoke test suite.

### Changes
| File | Description |
|------|-------------|
| `src/app/[locale]/layout.tsx` | `generateMetadata()` with OG tags, Twitter card, canonical + hreflang per locale |
| `src/app/sitemap.ts` | Generates `/sitemap.xml` statically for all 3 locales |
| `src/app/robots.ts` | Generates `/robots.txt` allowing all crawlers |
| `public/cv.pdf` | CV placeholder (ready to replace with real PDF) |
| `vitest.config.ts` | Vitest config with jsdom environment and `@` path alias |
| `package.json` | Added `npm run test` script |
| `src/__tests__/cv.test.ts` | 6 smoke tests validating `cvData` shape and required fields |

## How to test
1. `npm run test` → 6 tests pass
2. `npm run build` → 0 errors, `/robots.txt` and `/sitemap.xml` pre-rendered statically
3. `npm run dev` → view page source at `/en` — check `<meta og:*>` and `<link rel="canonical">`
4. Visit `/sitemap.xml` — shows 3 locale URLs
5. Click "Download CV" in Hero — downloads `/cv.pdf`

Closes #4
