### PR TITLE
fix: resolve dark mode text color shift on scroll

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 
 /* ── Design tokens ─────────────────────────────────────── */
 :root {
+  color-scheme: light;
   --background: #fafafa;   /* zinc-50 */
   --foreground: #09090b;   /* zinc-950 */
   --surface: #ffffff;
@@ -13,6 +14,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: #09090b;   /* zinc-950 */
   --foreground: #fafafa;   /* zinc-50 */
   --surface: #18181b;      /* zinc-900 */
@@ -41,4 +43,18 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans), system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Force consistent antialiasing on all elements — prevents text color
+   shift during Framer Motion opacity animations in dark mode */
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Reset browser default link colors (prevents visited yellow in dark mode) */
+a {
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,8 +14,8 @@ const containerVariants = {
 };
 
 const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
+  hidden: { opacity: 0, y: 20, z: 0 },
+  visible: { opacity: 1, y: 0, z: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
 };
 
 export function Hero() {

--- a/src/components/sections/Languages.tsx
+++ b/src/components/sections/Languages.tsx
@@ -25,8 +25,8 @@ export function Languages() {
           {cvData.languages.map((lang, i) => (
             <motion.li
               key={lang.language}
-              initial={{ opacity: 0, x: -12 }}
-              whileInView={{ opacity: 1, x: 0 }}
+              initial={{ opacity: 0, x: -12, z: 0 }}
+              whileInView={{ opacity: 1, x: 0, z: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.35, delay: i * 0.08, ease: "easeOut" as const }}
               className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--surface)] px-5 py-3"

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -31,8 +31,8 @@ export function Skills() {
           {categoryOrder.map((category, i) => (
             <motion.div
               key={category}
-              initial={{ opacity: 0, y: 16 }}
-              whileInView={{ opacity: 1, y: 0 }}
+              initial={{ opacity: 0, y: 16, z: 0 }}
+              whileInView={{ opacity: 1, y: 0, z: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.4, delay: i * 0.07, ease: "easeOut" as const }}
               className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5"


### PR DESCRIPTION
## Summary
Fixes white text turning yellow/warm when scrolling in dark mode. Two root causes combined to produce the bug.

### Root causes
1. **Missing `color-scheme`** — without `color-scheme: dark` on `.dark`, the browser doesn't know to use dark-mode text rendering, causing subpixel antialiasing to apply a warm tint to light text on dark backgrounds.
2. **Framer Motion opacity animations reset antialiasing** — `-webkit-font-smoothing` was only set on `body`. Child elements being animated from `opacity: 0 → 1` revert to subpixel antialiasing individually during the transition, making text appear yellowish until the animation settles.

### Changes
| File | Change |
|------|--------|
| `globals.css` | `color-scheme: light/dark` on `:root`/`.dark`; `* { -webkit-font-smoothing: antialiased }` for all elements; `a { color: inherit }` to prevent visited link yellow |
| `Hero.tsx` | `z: 0` added to Framer Motion variants to force GPU compositing |
| `Skills.tsx` | `z: 0` added to `initial` / `whileInView` |
| `Languages.tsx` | `z: 0` added to `initial` / `whileInView` |

## How to test
1. Enable dark mode
2. `npm run dev` → hard refresh (`Ctrl+Shift+R`) at `localhost:3000/en`
3. Scroll down through all sections — text should remain pure white throughout
4. Verify Skills cards and Languages items animate in without any colour shift
5. `next build` passes 0 errors

Closes #11
