### PR TITLE
feat: bold role text in Experience section

### DIFF
--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -30,7 +30,7 @@ export function Experience() {
 
                 {/* Right: role + highlights */}
                 <div className="flex flex-col gap-2">
-                  <p className="text-sm font-medium text-[var(--text-muted)]">{job.role}</p>
+                  <p className="text-sm font-bold text-[var(--foreground)]">{job.role}</p>
                   <ul className="flex flex-col gap-1" aria-label={`Highlights at ${job.company}`}>
                     {job.highlights.map((h) => (
                       <li key={h} className="flex gap-2 text-sm text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary
Changes the job role text in the Professional Experience section from `font-medium text-muted` to `font-bold text-foreground`, making it visually distinct from the highlight bullet points.

## Changes
- `src/components/sections/Experience.tsx`: role `<p>` updated with `font-bold` and `--foreground` color

## How to test
1. Run `npm run dev`
2. Navigate to the Professional Experience section
3. Verify each job role appears **bold** and in the primary foreground color, clearly standing out from the bullet point highlights

Closes #13