### PR TITLE
docs: update README with portfolio identity and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,27 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Marc Ruiz — Portfolio
 
-## Getting Started
+Personal portfolio of **Marc Ruiz**, Senior Software Engineer & Product Lead based in Girona, Spain.
 
-First, run the development server:
+Built with Next.js 14+ (App Router), Tailwind CSS, Framer Motion, and next-intl — available in 🇬🇧 English, 🇪🇸 Spanish and 🇫🇷 French.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+🔗 [linkedin.com/in/marcruiz11](https://linkedin.com/in/marcruiz11) · [github.com/markusrc11](https://github.com/markusrc11)
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+---
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Tech Stack
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 14+ (App Router) |
+| Styling | Tailwind CSS v4 (Zinc/Slate palette) |
+| Animations | Framer Motion v12 |
+| i18n | next-intl (EN / ES / FR) |
+| Testing | Vitest |
 
-## Learn More
+## Contributing / Development
 
-To learn more about Next.js, take a look at the following resources:
+Every change follows the **issue → branch → PR** workflow:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Open a GitHub Issue
+2. Branch as `feat/issue-[n]-[description]` or `fix/issue-[n]-[description]`
+3. Open a PR referencing `Closes #N`

--- a/README.md
+++ b/README.md
@@ -17,11 +17,3 @@ Built with Next.js 14+ (App Router), Tailwind CSS, Framer Motion, and next-intl 
 | Animations | Framer Motion v12 |
 | i18n | next-intl (EN / ES / FR) |
 | Testing | Vitest |
-
-## Contributing / Development
-
-Every change follows the **issue → branch → PR** workflow:
-
-1. Open a GitHub Issue
-2. Branch as `feat/issue-[n]-[description]` or `fix/issue-[n]-[description]`
-3. Open a PR referencing `Closes #N`


### PR DESCRIPTION
## Summary
Replaces the default Next.js boilerplate README with a concise, project-specific one that identifies this as Marc Ruiz's personal portfolio.

## Changes
- `README.md`: replaced boilerplate with portfolio intro, tech stack table, and dev workflow guidelines

## How to test
1. Open `README.md` at the repo root
2. Verify it shows the portfolio description, tech stack table, and workflow section

Closes #15