### PR TITLE
feat: show nickname in Navbar instead of full name

### DIFF
--- a/src/components/sections/Navbar.tsx
+++ b/src/components/sections/Navbar.tsx
@@ -7,7 +7,7 @@ export function Navbar() {
     <header className="fixed inset-x-0 top-0 z-50 border-b border-[var(--border)] bg-[var(--background)]/80 backdrop-blur-sm">
       <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-3">
         <span className="text-sm font-semibold tracking-tight text-[var(--foreground)]">
-          {cvData.personalInfo.name}
+          {cvData.personalInfo.nickname}
         </span>
         <div className="flex items-center gap-3">
           <LanguageSwitcher />

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -3,6 +3,7 @@
 export const cvData = {
   personalInfo: {
     name: "Marc Ruiz",
+    nickname: "@markusrc11",
     role: "Senior Software Engineer | Product & Project Lead",
     specialization: "Python, Java & Kotlin Specialist",
     location: "Girona, Spain",


### PR DESCRIPTION
## Summary
Navbar now displays `@markusrc11` instead of the full name.

## Changes
- `src/data/cv.ts`: added `nickname: "@markusrc11"`
- `src/components/sections/Navbar.tsx`: uses `personalInfo.nickname`

## How to test
1. Run `npm run dev`
2. Verify top-left of Navbar shows `@markusrc11`

Closes #20