### PR TITLE
fix: reduce Hero section vertical spacing

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -23,7 +23,7 @@ export function Hero() {
 
   return (
     <section
-      className="flex min-h-[90vh] flex-col items-center justify-center px-6 py-24 text-center"
+      className="flex min-h-[60vh] flex-col items-center justify-center px-6 py-12 text-center"
       aria-label="Hero"
     >
       <motion.div


### PR DESCRIPTION
## Summary
Reduced excessive vertical space in the Hero section.

## Changes
- `src/components/sections/Hero.tsx`: `min-h-[90vh]` → `min-h-[60vh]`, `py-24` → `py-12`

## How to test
1. Run `npm run dev`
2. Verify the Hero is more compact and the Professional Summary is closer

Closes #21