### PR TITLE
fix: real production URL for metadata/robots/sitemap

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { getMessages, getTranslations } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
 import { routing } from "@/i18n/routing";
 import { cvData } from "@/data/cv";
+import { SITE_URL } from "@/lib/site";
 import "../globals.css";
 import { notFound } from "next/navigation";
 
@@ -26,16 +27,16 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "Index" });
   const { personalInfo } = cvData;
-  const url = `https://marcruiz.dev/${locale}`;
+  const url = `${SITE_URL}/${locale}`;
 
   return {
     title: t("title"),
     description: t("description"),
-    metadataBase: new URL("https://marcruiz.dev"),
+    metadataBase: new URL(SITE_URL),
     alternates: {
       canonical: url,
       languages: Object.fromEntries(
-        routing.locales.map((loc) => [loc, `https://marcruiz.dev/${loc}`])
+        routing.locales.map((loc) => [loc, `${SITE_URL}/${loc}`])
       ),
     },
     openGraph: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },
-    sitemap: "https://marcruiz.dev/sitemap.xml",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,16 @@
 import type { MetadataRoute } from "next";
 import { routing } from "@/i18n/routing";
+import { SITE_URL } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return routing.locales.map((locale) => ({
-    url: `https://marcruiz.dev/${locale}`,
+    url: `${SITE_URL}/${locale}`,
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: locale === routing.defaultLocale ? 1 : 0.8,
     alternates: {
       languages: Object.fromEntries(
-        routing.locales.map((loc) => [loc, `https://marcruiz.dev/${loc}`])
+        routing.locales.map((loc) => [loc, `${SITE_URL}/${loc}`])
       ),
     },
   }));

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,2 @@
+/** Public production URL. Used for canonical/OG metadata, robots and sitemap. */
+export const SITE_URL = "https://marcruiz.vercel.app";


### PR DESCRIPTION
Replaces the placeholder `marcruiz.dev` with the real production URL `https://marcruiz.vercel.app`, centralized in `src/lib/site.ts`.

Affects: canonical + OpenGraph metadata, `robots.txt` sitemap reference, and `sitemap.xml` URLs.

## Test plan
- [x] `grep marcruiz.dev` → no matches
- [x] `npm run build` (OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)