### PR TITLE
feat: localized dates, experience locations & apple icon

### DIFF
--- a/src/__tests__/cv.test.ts
+++ b/src/__tests__/cv.test.ts
@@ -24,10 +24,13 @@ describe("cvData shape", () => {
     expect(cvData.experience.length).toBeGreaterThan(0);
     for (const job of cvData.experience) {
       expect(job.company).toBeTruthy();
-      expect(job.period).toBeTruthy();
+      expect(job.start.year).toBeGreaterThan(0);
+      expect(job.start.month).toBeGreaterThanOrEqual(1);
+      expect(job.start.month).toBeLessThanOrEqual(12);
       expect(job.tech.length).toBeGreaterThan(0);
       for (const locale of LOCALES) {
         expect(job.role[locale]).toBeTruthy();
+        expect(job.location[locale]).toBeTruthy();
         expect(job.highlights[locale].length).toBeGreaterThan(0);
       }
     }

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+// Apple touch icon — iOS applies its own rounded mask, so we fill the square.
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#18181b",
+          color: "#fafafa",
+          fontSize: 120,
+          fontWeight: 700,
+          fontFamily: "Arial, Helvetica, sans-serif",
+        }}
+      >
+        M
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -1,6 +1,7 @@
 import { useTranslations, useLocale } from "next-intl";
 import { SectionTitle } from "@/components/ui/SectionTitle";
 import { cvData } from "@/data/cv";
+import { formatRange } from "@/lib/dates";
 
 type SupportedLocale = "en" | "es" | "fr";
 
@@ -18,11 +19,12 @@ export function Experience() {
 
         <ol className="flex flex-col gap-10">
           {cvData.experience.map((job) => {
-            const period = job.period.replace("Present", tCommon("present"));
+            const period = formatRange(job.start, job.end, locale, tCommon("present"));
             const role = job.role[locale] ?? job.role.en;
+            const location = job.location[locale] ?? job.location.en;
             const highlights = job.highlights[locale] ?? job.highlights.en;
             return (
-              <li key={`${job.company}-${job.period}`} className="relative grid gap-1 sm:grid-cols-[1fr_2fr]">
+              <li key={`${job.company}-${job.start.year}`} className="relative grid gap-1 sm:grid-cols-[1fr_2fr]">
                 {/* Left: meta */}
                 <div className="flex flex-col gap-1">
                   <time className="text-xs font-medium text-[var(--text-muted)]">
@@ -31,6 +33,7 @@ export function Experience() {
                   <span className="text-sm font-semibold text-[var(--foreground)]">
                     {job.company}
                   </span>
+                  <span className="text-xs text-[var(--text-muted)]">{location}</span>
                 </div>
 
                 {/* Right: role + highlights */}

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -30,7 +30,13 @@ export const cvData = {
   experience: [
     {
       company: "Spoki",
-      period: "Feb 2026 – Present",
+      start: { year: 2026, month: 2 },
+      end: null as { year: number; month: number } | null,
+      location: {
+        en: "Remote — Girona, Spain",
+        es: "Remoto — Girona, España",
+        fr: "À distance — Gérone, Espagne"
+      },
       tech: ["Python", "OpenAI", "FastAPI", "Django"],
       role: {
         en: "AI Software Engineer",
@@ -57,7 +63,13 @@ export const cvData = {
     },
     {
       company: "Studentan",
-      period: "Apr 2025 – Present",
+      start: { year: 2025, month: 4 },
+      end: null as { year: number; month: number } | null,
+      location: {
+        en: "Remote — Geneva, Switzerland",
+        es: "Remoto — Ginebra, Suiza",
+        fr: "À distance — Genève, Suisse"
+      },
       tech: ["PHP", "Alpine.js", "TailwindCSS"],
       role: {
         en: "Full Stack Developer (Freelance)",
@@ -81,7 +93,13 @@ export const cvData = {
     },
     {
       company: "Gisce-TI",
-      period: "Dec 2021 – Feb 2026",
+      start: { year: 2021, month: 12 },
+      end: { year: 2026, month: 2 } as { year: number; month: number } | null,
+      location: {
+        en: "Girona, Spain",
+        es: "Girona, España",
+        fr: "Gérone, Espagne"
+      },
       tech: ["Kotlin", "Java", "Python", "MongoDB"],
       role: {
         en: "Software Engineer",
@@ -108,7 +126,13 @@ export const cvData = {
     },
     {
       company: "Newronia",
-      period: "Nov 2016 – Dec 2019",
+      start: { year: 2016, month: 11 },
+      end: { year: 2019, month: 12 } as { year: number; month: number } | null,
+      location: {
+        en: "Girona, Spain",
+        es: "Girona, España",
+        fr: "Gérone, Espagne"
+      },
       tech: ["Java", "Python", "AWS"],
       role: {
         en: "Software Developer",

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,24 @@
+type Locale = "en" | "es" | "fr";
+
+/** Month is 1-indexed (1 = January). */
+export type YearMonth = { year: number; month: number };
+
+function formatMonthYear(date: YearMonth, locale: Locale): string {
+  const formatted = new Intl.DateTimeFormat(locale, {
+    month: "short",
+    year: "numeric",
+  }).format(new Date(date.year, date.month - 1, 1));
+  // Spanish/French abbreviated months come lowercased — capitalize for a CV look.
+  return formatted.charAt(0).toUpperCase() + formatted.slice(1);
+}
+
+export function formatRange(
+  start: YearMonth,
+  end: YearMonth | null,
+  locale: Locale,
+  presentLabel: string
+): string {
+  const startLabel = formatMonthYear(start, locale);
+  const endLabel = end ? formatMonthYear(end, locale) : presentLabel;
+  return `${startLabel} – ${endLabel}`;
+}


### PR DESCRIPTION
- **Localized month names**: experience dates are now structured (`{year, month}`) and formatted per locale with `Intl` (e.g. ES `Dic 2021`, FR `Févr. 2026`). `Present` keeps using the i18n label.
- **Experience locations**: each job shows a localized location (`Remote — Girona, Spain`, etc.), like the reference repo.
- **Apple touch icon**: `app/apple-icon.tsx` renders the `M` monogram at 180×180 for iOS home-screen bookmarks.

## Test plan
- [x] `npm run test` (6/6)
- [x] `npm run build` (OK — `/apple-icon` + `/icon.svg` routes generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)