### PR TITLE
feat: hero availability pill + Side Projects rename

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -6,7 +6,8 @@
   "Hero": {
     "title": "Building and shipping production systems end-to-end — Python services, cloud infrastructure and LLM-powered features.",
     "subtitle": "Backend & AI Software Engineer",
-    "cta": "Download CV"
+    "cta": "Download CV",
+    "availability": "Open to remote or relocation"
   },
   "Nav": {
     "skills": "Skills",
@@ -20,7 +21,7 @@
     "experience": "Professional Experience",
     "education": "Education",
     "languages": "Languages",
-    "projects": "Selected Projects",
+    "projects": "Side Projects",
     "contact": "Get in touch"
   },
   "Contact": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,7 +6,8 @@
   "Hero": {
     "title": "Construyo y despliego sistemas en producción de principio a fin — servicios en Python, infraestructura cloud y funcionalidades con LLM.",
     "subtitle": "Ingeniero de Software Backend e IA",
-    "cta": "Descargar CV"
+    "cta": "Descargar CV",
+    "availability": "Abierto a trabajo remoto o reubicación"
   },
   "Nav": {
     "skills": "Habilidades",
@@ -20,7 +21,7 @@
     "experience": "Experiencia Profesional",
     "education": "Formación",
     "languages": "Idiomas",
-    "projects": "Proyectos Destacados",
+    "projects": "Proyectos Personales",
     "contact": "Hablemos"
   },
   "Contact": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -6,7 +6,8 @@
   "Hero": {
     "title": "Je conçois et déploie des systèmes en production de bout en bout — services Python, infrastructure cloud et fonctionnalités basées sur les LLM.",
     "subtitle": "Ingénieur Logiciel Backend & IA",
-    "cta": "Télécharger le CV"
+    "cta": "Télécharger le CV",
+    "availability": "Ouvert au télétravail ou à la mobilité géographique"
   },
   "Nav": {
     "skills": "Compétences",
@@ -20,7 +21,7 @@
     "experience": "Expérience Professionnelle",
     "education": "Éducation",
     "languages": "Langues",
-    "projects": "Projets Sélectionnés",
+    "projects": "Projets Personnels",
     "contact": "Contact"
   },
   "Contact": {

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -41,11 +41,15 @@ export function Hero() {
         initial="hidden"
         animate="visible"
       >
-        {/* Location pill */}
-        <motion.div variants={itemVariants}>
+        {/* Location + availability pills */}
+        <motion.div variants={itemVariants} className="flex flex-wrap items-center justify-center gap-2">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-3 py-1 text-xs text-[var(--text-muted)]">
             <MapPin size={12} aria-hidden="true" />
             {personalInfo.location}
+          </span>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-3 py-1 text-xs text-[var(--text-muted)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-green-500" aria-hidden="true" />
+            {t("availability")}
           </span>
         </motion.div>
 

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -29,7 +29,18 @@ export function Projects() {
               className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5"
             >
               <h3 className="text-sm font-semibold text-[var(--foreground)]">
-                {project.name}
+                {project.url ? (
+                  <a
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors hover:text-[var(--text-muted)]"
+                  >
+                    {project.name} ↗
+                  </a>
+                ) : (
+                  project.name
+                )}
               </h3>
               <p className="mt-2 text-sm text-[var(--text-muted)]">
                 {project.description[locale] ?? project.description.en}

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -205,10 +205,8 @@ export const cvData = {
       level: { en: "B1 (Intermediate)", es: "B1 (Intermedio)", fr: "B1 (Intermédiaire)" }
     }
   ],
-  // TODO: add selected projects here to enable the Projects section
-  // (it stays hidden while this array is empty). Candidates:
-  //  - Spoki GenAI product (OpenAI LLM + image generation)
-  //  - AWS route-optimization engine (Newronia, fleet of 50+ trucks)
+  // TODO: add side projects here to enable the Projects section
+  // (it stays hidden while this array is empty).
   projects: [] as {
     name: string;
     description: { en: string; es: string; fr: string };


### PR DESCRIPTION
- **Availability pill** in the hero: localized "Open to remote or relocation" with a status dot, next to the location pill (mirrors the reference repo).
- **Projects section** heading renamed to **Side Projects** (`Proyectos Personales` / `Projets Personnels`). Section stays hidden while `cvData.projects` is empty.
- Projects card links to the repo URL when provided.

## Test plan
- [x] `npm run test` (6/6)
- [x] `npm run build` (OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)